### PR TITLE
Add a `version` command

### DIFF
--- a/cmd/ax/main.go
+++ b/cmd/ax/main.go
@@ -22,7 +22,9 @@ var (
 	queryCommand    = kingpin.Command("query", "Query logs").Default()
 	alertCommand    = kingpin.Command("alert", "Be alerted when logs match a query")
 	alertDCommand   = kingpin.Command("alertd", "Be alerted when logs match a query")
+	versionCommand  = kingpin.Command("version", "Show the ax version")
 	addAlertCommand = alertCommand.Command("add", "Add new alert")
+	version         = "dev"
 )
 
 func determineClient(em config.EnvMap) common.Client {
@@ -86,6 +88,8 @@ func main() {
 		addAlertMain(rc, client)
 	case "alertd":
 		alertMain(ctx, rc)
+	case "version":
+		println(version)
 	}
 
 }


### PR DESCRIPTION
Prints the value of `main.version`. It is `dev` by default, but
overriden by `goreleaser` with the tag name.

To try this out without `goreleaser`:
```
$ go install -ldflags "-X main.version=foo" github.com/egnyte/ax/cmd/ax
$ ax version
foo
```