### PR TITLE
Fix upgrades

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,7 @@
 builds:
   - binary: ax
     main: ./cmd/ax
+    ldflags: -s -w -X main.version={{.Tag}} -X main.commit={{.Commit}} -X main.date={{.Date}}
     goos:
       - darwin
       - linux
@@ -9,4 +10,3 @@ builds:
       - 386
 archive:
   name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-  

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,3 +7,6 @@ builds:
     goarch:
       - amd64
       - 386
+archive:
+  name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  


### PR DESCRIPTION
Fixes https://github.com/egnyte/ax/issues/38
This pull requests does 2 things:

1. fixes upgrades - before goreleaser was creating build with version which wasn't including **v** from github tag, then when ax wanted to upgrade it was comparing this version without v with github tag. This caused situation where ax thought there is new version (v0.3.2 != 0.3.2) where there was no new version
2. changes names of archives to include **v** in version name

With these changes version == tag. It is consistent.